### PR TITLE
Acc verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # alpha-codegen
 
-This repo contains scripts that can be used to generate and compile simple demand driven C code from input Alpha programs.
-There are currently two versions of AlphaZ ("alphaz" [v1](https://github.com/CSU-CS-Melange/AlphaZ) and "alpha-language" [v2](https://github.com/CSU-CS-Melange/alpha-language)) included here as submodules.
-This repository contains two bundles, one for each, which wrap and expose the respective codegen entry points.
+This repo contains a utility that can be used to generate and compile simple demand driven C code from input Alpha programs.
+Code generation in AlphaZ is currently split across two versions ("alphaz" [v1](https://github.com/CSU-CS-Melange/AlphaZ) and "alpha-language" [v2](https://github.com/CSU-CS-Melange/alpha-language)) referenced here as submodules.
+This repo contains two bundles, one for each, which wrap and expose the respective code generation entry points.
 
 ## Alpha to C Compiler (acc)
 
@@ -30,6 +30,7 @@ options:
          --target-complexity   : Target simplified complexity (default: one less than
                                  the input program's complexity)
          --try-splitting       : Consider splits during simplification (default: false)
+    -v,  --verbose             : Emit debug information during simplification exploration
 arguments:
     ALPHA_FILE                 : Input Alpha file used to generate main ystem, makefile,
                                  wrapper, and verification files. (required if neither 
@@ -58,7 +59,7 @@ You may wish to add this to your path with the following command:
 This will install the `acc` utility in your home directory.
 You may optionally wish to add this to your shell's PATH.
 Note, this depends on java and your `JAVA_HOME` environment variable must point to a jdk of at least version 11.
-Alternatively, you can follow the steps in the following sections to build everything from source.
+Alternatively, you can follow the steps below to build everything from source.
 
 
 # Usage
@@ -67,9 +68,9 @@ Take a single-system Alpha program such as the following,
 ```
 // test.alpha
 affine prefix_sum [N] -> {: 10<N}
-	inputs X : [N]
-	outputs	Y : [N]
-	let	Y = reduce(+, (i,j->i), {: 0<=j<=i} : X[j]);
+	inputs  X : [N]
+	outputs Y : [N]
+	let     Y = reduce(+, (i,j->i), {: 0<=j<=i} : X[j]);
 .
 ```
 
@@ -93,7 +94,7 @@ $ acc -o out-1 test.alpha
 [acc]: created 'out-1/Makefile' file
 ```
 
-The `out-1` directory will now look like this,
+A new directory called `out-1` will be created and will look like this,
 ```
 out-1
 ├── Makefile
@@ -140,14 +141,14 @@ Execution time : 0.000005 sec.
 TEST for Y PASSED
 ```
 
-The verification targets use the old WriteC.
+The verification targets use the old WriteC code generator.
 This can be used to bug check the new code generator (assuming the same bug is not also present in the old one).
 If verification reports "TEST ... PASSED", then it confirms that the new code generator produces a program that computes the same answer as the old code generator.
 This can also be used to sanity check that any optimized versions compute the same answer (i.e., remain semantically equivalent).
 
 ## Generate demand driven code with simplification
 
-Take the same input prefix sum program above and run the `acc` script but this time pass the `-s` option and ask to report up to 10 simplifications with the `--num-simplifications 10` option,
+Take the same prefix sum program above and run the `acc` script but this time ask it to try to simplify the program by passing the `-s` option and ask it to report at most two simplifications with the `--num-simplifications 2` option,
 ```
 $ acc -o out-2 -s --num-simplifications 10 test.alpha
 [acc]: reading 'test.alpha' file

--- a/artifact/bin/acc
+++ b/artifact/bin/acc
@@ -36,6 +36,8 @@ function usage {
   echo "         --target-complexity   : Target simplified complexity (default: one less than"
   echo "                                 the input program's complexity)"
   echo "         --try-splitting       : Consider splits during simplification (default: false)"
+  echo "    -v,  --verbose             : Emit debug information during simplification exploration"
+
   echo "arguments:"
   echo "    ALPHA_FILE                 : Input Alpha file used to generate main ystem, makefile,"
   echo "                                 wrapper, and verification files. (required if neither "
@@ -98,6 +100,10 @@ while (( "$#" )); do
       ;;
     --try-splitting)
       try_splitting=1;
+      shift 1
+      ;;
+    -v|--verbose)
+      verbose=1;
       shift 1
       ;;
     --num-simplifications)
@@ -210,7 +216,8 @@ if [[ -n "$gen_new_writeC" ]]; then
          ACC_SIMPLIFY=$simplify \
          ACC_NUM_SIMPLIFICATIONS=$num_simplifications \
          ACC_TARGET_COMPLEXITY=$target_complexity \
-         ACC_TRY_SPLITTING=$try_splitting
+         ACC_TRY_SPLITTING=$try_splitting \
+         ACC_VERBOSE=$verbose
   java -jar ${BASE_DIR}/alpha.glue.v2.jar
   statuz="$?"
   if [[ -z "$simplify" ]]; then

--- a/bundles/alpha.glue.v2/src/alpha/glue/v2/GenerateNewWriteC.xtend
+++ b/bundles/alpha.glue.v2/src/alpha/glue/v2/GenerateNewWriteC.xtend
@@ -32,6 +32,7 @@ class GenerateNewWriteC {
 	static int numOptimizations = parseInt(getenv('ACC_NUM_SIMPLIFICATIONS'), 1)
 	static int targetComplexity = parseInt(getenv('ACC_TARGET_COMPLEXITY'), -1)
 	static boolean trySplitting = !(getenv('ACC_TRY_SPLITTING').isNullOrEmpty)
+	static boolean verbose = !(getenv('ACC_VERBOSE').isNullOrEmpty)
 
 	def static parseInt(String str, int defaultValue) {
 		if (str.isNullOrEmpty) return defaultValue
@@ -80,7 +81,7 @@ class GenerateNewWriteC {
 //		SimplifyingReductions.DEBUG = debug
 		if (targetComplexity == -1)
 			targetComplexity = system.complexity - 1
-		val osr = OptimalSimplifyingReductions.apply(system, numOptimizations, targetComplexity, trySplitting)
+		val osr = OptimalSimplifyingReductions.apply(system, numOptimizations, targetComplexity, trySplitting, verbose)
 		
 		// All optimized roots are guaranteed to have a single system
 		osr.optimizations.get(targetComplexity)

--- a/bundles/alpha.glue.v2/xtend-gen/alpha/glue/v2/GenerateNewWriteC.java
+++ b/bundles/alpha.glue.v2/xtend-gen/alpha/glue/v2/GenerateNewWriteC.java
@@ -44,6 +44,8 @@ public class GenerateNewWriteC {
 
   private static boolean trySplitting = (!StringExtensions.isNullOrEmpty(System.getenv("ACC_TRY_SPLITTING")));
 
+  private static boolean verbose = (!StringExtensions.isNullOrEmpty(System.getenv("ACC_VERBOSE")));
+
   public static int parseInt(final String str, final int defaultValue) {
     int _xblockexpression = (int) 0;
     {
@@ -117,7 +119,7 @@ public class GenerateNewWriteC {
         int _minus = (_complexity - 1);
         GenerateNewWriteC.targetComplexity = _minus;
       }
-      final OptimalSimplifyingReductions osr = OptimalSimplifyingReductions.apply(system, GenerateNewWriteC.numOptimizations, GenerateNewWriteC.targetComplexity, GenerateNewWriteC.trySplitting);
+      final OptimalSimplifyingReductions osr = OptimalSimplifyingReductions.apply(system, GenerateNewWriteC.numOptimizations, GenerateNewWriteC.targetComplexity, GenerateNewWriteC.trySplitting, GenerateNewWriteC.verbose);
       _xblockexpression = osr.optimizations.get(Integer.valueOf(GenerateNewWriteC.targetComplexity));
     }
     return ((OptimalSimplifyingReductions.State[])Conversions.unwrapArray(_xblockexpression, OptimalSimplifyingReductions.State.class));


### PR DESCRIPTION
Adds a verbose option to acc to enable printing all of the debug info during OptimalSimplifyingReductions.

This requires changes to OptimalSimplifyingReductions in alpha-languages to make the DEBUG printing non-static. This can be seen in commit https://github.com/CSU-CS-Melange/alpha-language/pull/67/commits/1ecf02418c7028eae298fc35d7980f8606695f81, to which the alpha-language submodule here points.